### PR TITLE
Added conventional files for a repo within the OpenSearch project

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# This should match the owning team set up in https://github.com/orgs/opensearch-project/teams
+*   @AndreKurait @chelma @gregschohn @lewijacn @mikaylathompson @peternied @sumobrian @rlashofregas

--- a/.github/ISSUE_TEMPLATE/BUG_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE/BUG_TEMPLATE.md
@@ -1,0 +1,21 @@
+---
+name: 🐛 Bug Report
+about: Create a report to help us improve
+title: '[BUG]'
+labels: 'bug, untriaged'
+assignees: ''
+---
+### What is the bug?
+_A clear and concise description of the bug._
+
+### What are your migration environments?
+_What versions of Elasticsearch / Opensearch, what version of the Traffic Gateway._
+
+### How can one reproduce the bug?
+_Steps to reproduce the behavior._
+
+### What is the expected behavior?
+_A clear and concise description of what you expected to happen._
+
+### Do you have any additional context?
+_Add any other context about the problem, such as log files our console output._

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,15 @@
+### Description
+<!-- Describe what this change achieves -->
+
+### Issues Resolved
+<!-- List any GitHub or Jira issues this PR will resolve -->
+
+### Testing
+<!-- Please provide details of testing done: unit testing, integration testing and manual testing -->
+
+### Check List
+- [ ] New functionality includes testing
+- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.
+
+By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
+For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).

--- a/.github/release-notes-drafter-config.yml
+++ b/.github/release-notes-drafter-config.yml
@@ -1,0 +1,24 @@
+# Configuration for Release Drafter: https://github.com/toolmantim/release-drafter
+template: |
+  Compatible with OpenSearch (set version here).
+  $CHANGES
+
+# Setting the formatting and sorting for the release notes body
+name-template: Version (set version here)
+change-template: '* $TITLE ([#$NUMBER](https://github.com/opensearch-project/opensearch-migrations/pull/$NUMBER))'
+sort-by: merged_at
+sort-direction: ascending
+replacers:
+  - search: "##"
+    replace: "###"
+
+# Organizing the tagged PRs into unified ODFE categories
+categories:
+  - title: "Enhancements"
+    labels: "enhancement"
+
+  - title: "Bug fixes"
+    labels: "bug"
+
+  - title: "Maintenance"
+    labels: "maintenance"

--- a/.github/workflows/add-untriaged.yml
+++ b/.github/workflows/add-untriaged.yml
@@ -1,0 +1,19 @@
+name: Apply 'untriaged' label during issue lifecycle
+
+on:
+  issues:
+    types: [opened, reopened, transferred]
+
+jobs:
+  apply-label:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            github.rest.issues.addLabels({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: ['untriaged']
+            })

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,2 @@
+# This should match the owning team set up in https://github.com/orgs/opensearch-project/teams
+*   @AndreKurait @chelma @gregschohn @lewijacn @mikaylathompson @peternied @sumobrian

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,15 @@
+### Description
+<!-- Describe what this change achieves -->
+
+### Issues Resolved
+<!-- List any GitHub or Jira issues this PR will resolve -->
+
+### Testing
+<!-- Please provide details of testing done: unit testing, integration testing and manual testing -->
+
+### Check List
+- [ ] New functionality includes testing
+- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.
+
+By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
+For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).

--- a/release-notes-drafter-config.yml
+++ b/release-notes-drafter-config.yml
@@ -1,0 +1,24 @@
+# Configuration for Release Drafter: https://github.com/toolmantim/release-drafter
+template: |
+  Compatible with OpenSearch (set version here).
+  $CHANGES
+
+# Setting the formatting and sorting for the release notes body
+name-template: Version (set version here)
+change-template: '* $TITLE ([#$NUMBER](https://github.com/opensearch-project/opensearch-traffic-gateway/pull/$NUMBER))'
+sort-by: merged_at
+sort-direction: ascending
+replacers:
+  - search: "##"
+    replace: "###"
+
+# Organizing the tagged PRs into unified ODFE categories
+categories:
+  - title: "Enhancements"
+    labels: "enhancement"
+
+  - title: "Bug fixes"
+    labels: "bug"
+
+  - title: "Maintenance"
+    labels: "maintenance"


### PR DESCRIPTION
### Description
Added template files that are boilerplate for repos within the OpenSearch project.

### Issues Resolved
N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
